### PR TITLE
feat: use notyf for all notifications and fix typing errors

### DIFF
--- a/src/app/interfaces/social-media.interface.ts
+++ b/src/app/interfaces/social-media.interface.ts
@@ -1,6 +1,23 @@
 export interface SocialMedia {
-  facebook: string;
-  instagram: string;
-  youtube: string;
-  whatsapp: string;
+  instagram: {
+    username: string;
+    url: string;
+    displayName: string;
+  };
+  facebook: {
+    username: string;
+    url: string;
+    displayName: string;
+  };
+  tiktok: {
+    username: string;
+    url: string;
+    displayName: string;
+  };
+  whatsapp: {
+    number: string;
+    url: string;
+    displayName: string;
+    formattedNumber: string;
+  };
 }

--- a/src/app/pages/admin/edicao-detalhe/edicao-detalhe.ts
+++ b/src/app/pages/admin/edicao-detalhe/edicao-detalhe.ts
@@ -40,7 +40,9 @@ export class EdicaoDetalheComponent {
       this.form.get('pdf')?.updateValueAndValidity();
     } else {
       this.notificationService.error('Por favor, selecione um arquivo PDF válido.');
-      event.target.value = '';
+      if (target) {
+        target.value = '';
+      }
     }
   }
 
@@ -51,14 +53,18 @@ export class EdicaoDetalheComponent {
       const allowedTypes = ['image/jpeg', 'image/jpg', 'image/png', 'image/webp'];
       if (!allowedTypes.includes(file.type)) {
         this.notificationService.error('Por favor, selecione uma imagem válida (JPEG, PNG ou WebP).');
-        event.target.value = '';
+        if (target) {
+          target.value = '';
+        }
         return;
       }
       
       const maxSize = 5 * 1024 * 1024; // 5MB
       if (file.size > maxSize) {
         this.notificationService.warning('A imagem deve ter no máximo 5MB.');
-        event.target.value = '';
+        if (target) {
+          target.value = '';
+        }
         return;
       }
       

--- a/src/app/pages/public/cadastro-cao/cadastro-cao.ts
+++ b/src/app/pages/public/cadastro-cao/cadastro-cao.ts
@@ -29,7 +29,7 @@ import {
   CadastroCaoResponse,
 } from "../../../interfaces/cao.interface";
 import { SocialMedia } from "../../../interfaces/social-media.interface";
-import { User } from "../../../interfaces/usuario.interface";
+import { Usuario as User } from "../../../interfaces/usuario.interface";
 
 @Component({
   selector: "app-cadastro-cao",
@@ -291,7 +291,9 @@ export class CadastroCaoComponent implements OnInit, OnDestroy {
     if (file) {
       const validation = this.validationService.validateImageFile(file);
       if (!validation.valid) {
-        this.notificationService.error(validation.error);
+        if (validation.error) {
+          this.notificationService.error(validation.error);
+        }
         return;
       }
       this.fotoPerfil = file;
@@ -307,7 +309,9 @@ export class CadastroCaoComponent implements OnInit, OnDestroy {
     if (file) {
       const validation = this.validationService.validateImageFile(file);
       if (!validation.valid) {
-        this.notificationService.error(validation.error);
+        if (validation.error) {
+          this.notificationService.error(validation.error);
+        }
         return;
       }
       this.fotoLateral = file;
@@ -341,7 +345,9 @@ export class CadastroCaoComponent implements OnInit, OnDestroy {
     if (file) {
       const validation = this.validationService.validateImageFile(file);
       if (!validation.valid) {
-        this.notificationService.error(validation.error);
+        if (validation.error) {
+          this.notificationService.error(validation.error);
+        }
         return;
       }
       this.pedigreeFrente = file;
@@ -354,7 +360,9 @@ export class CadastroCaoComponent implements OnInit, OnDestroy {
     if (file) {
       const validation = this.validationService.validateImageFile(file);
       if (!validation.valid) {
-        this.notificationService.error(validation.error);
+        if (validation.error) {
+          this.notificationService.error(validation.error);
+        }
         return;
       }
       this.pedigreeVerso = file;
@@ -367,7 +375,9 @@ export class CadastroCaoComponent implements OnInit, OnDestroy {
     if (file) {
       const validation = this.validationService.validateVideoFile(file);
       if (!validation.valid) {
-        this.notificationService.error(validation.error);
+        if (validation.error) {
+          this.notificationService.error(validation.error);
+        }
         return;
       }
       if (validation.warning && !window.confirm(validation.warning)) {

--- a/src/app/pages/public/profile/profile.ts
+++ b/src/app/pages/public/profile/profile.ts
@@ -154,8 +154,8 @@ export class ProfileComponent implements OnInit, OnDestroy {
     this.selectedCadastro = cadastro;
     const currentOption = cadastro.videoOption || "NONE";
     const validOptions: ("UPLOAD" | "URL" | "WHATSAPP" | "NONE")[] = ["UPLOAD", "URL", "WHATSAPP", "NONE"];
-    this.videoOption = validOptions.includes(currentOption)
-      ? currentOption
+    this.videoOption = validOptions.includes(currentOption as any)
+      ? (currentOption as "UPLOAD" | "URL" | "WHATSAPP" | "NONE")
       : "NONE";
     this.videoUrl = cadastro.videoUrl || "";
     this.confirmaWhatsapp = !!cadastro.whatsappContato;


### PR DESCRIPTION
Replaced all instances of `alert()` with the `NotificationService` to ensure a consistent notification style across the application.

Fixed several TypeScript compilation errors by:
- Correctly casting `event.target` to `HTMLInputElement` in `edicao-detalhe.ts`.
- Updating the import for the `User` interface in `cadastro-cao.ts`.
- Updating the `SocialMedia` interface to match the structure of the `social-media.service.ts` object.
- Adding checks to ensure that `validation.error` is not `undefined` before passing it to `notificationService.error()` in `cadastro-cao.ts`.
- Adjusting the logic in the `openVideoModal` method in `profile.ts` to correctly assign a value to `this.videoOption`.

Removed unnecessary comments from the codebase to improve readability.