### PR TITLE
refactor: remove redundant alias methods and getters in CaesComponent

### DIFF
--- a/src/app/pages/admin/caes/caes.html
+++ b/src/app/pages/admin/caes/caes.html
@@ -5,16 +5,16 @@
       Cães Cadastrados
     </h1>
     <div class="page-actions">
-      @if (canManageBreeds()) {
+      @if (isAdmin) {
         <button pButton type="button" icon="pi pi-cog" label="Gerenciar Raças"
-          (click)="openBreedModal()"
+          (click)="openRacaModal()"
         ></button>
       }
       <button pButton type="button" icon="pi pi-plus" label="Cadastrar Cão" (click)="navigateToCadastro()"></button>
     </div>
   </div>
 
-  @if (!isLoading) {
+  @if (!loading) {
     <div class="caes-table-container">
       <div class="table-header">
         <h2>Lista de Cães ({{ filteredCaes.length }})</h2>
@@ -51,7 +51,7 @@
               </div>
             </td>
             <td>{{ getRacaName(cao.racaId) || cao.raca?.nome || 'N/A' }}</td>
-            <td>{{ formatAge(cao.dataNascimento) }}</td>
+            <td>{{ calculateAge(cao.dataNascimento) }}</td>
             <td>{{ cao.donoCao?.nome || 'N/A' }}</td>
             <td>{{ formatDate(cao.createdAt) }}</td>
             <td>
@@ -85,7 +85,7 @@
             <td>
               <div class="action-buttons">
                 <button pButton type="button" icon="pi pi-eye" class="p-button-rounded p-button-text" (click)="openCaoModal(cao)" title="Visualizar"></button>
-                <button pButton type="button" icon="pi pi-pencil" class="p-button-rounded p-button-text" (click)="editCao(cao)" title="Editar"></button>
+                <button pButton type="button" icon="pi pi-pencil" class="p-button-rounded p-button-text" (click)="openCaoModal(cao)" title="Editar"></button>
               </div>
             </td>
           </tr>
@@ -95,7 +95,7 @@
         <div class="empty-state">
           <i class="fas fa-dog"></i>
           <h3>Nenhum cão encontrado</h3>
-          @if (searchTerm || selectedBreedId) {
+          @if (searchTerm || selectedRaca) {
             <p>
               Tente ajustar os filtros de busca ou
               <button class="btn-link" (click)="clearFilters()">
@@ -103,7 +103,7 @@
               </button>
             </p>
           }
-          @if (!searchTerm && !selectedBreedId) {
+          @if (!searchTerm && !selectedRaca) {
             <p>
               Ainda não há cães cadastrados no sistema.
             </p>
@@ -124,15 +124,15 @@
   [visible]="showRacaModal"
   (visibleChange)="showRacaModal = $event"
   [racas]="racas"
-  [currentBreed]="currentBreed"
-  [isSavingBreed]="isSavingBreed"
-  [editingBreedId]="editingBreedId"
+  [currentBreed]="racaForm"
+  [isSavingBreed]="racaModalLoading"
+  [editingBreedId]="isEditingRaca ? racaForm.racaId : null"
   [racaSearchTerm]="racaSearchTerm"
-  (racaSearchTermChange)="racaSearchTerm = $event; onRacaFilterChange()"
-  (cancel)="cancelBreedEdit()"
-  (save)="saveBreed()"
-  (edit)="editBreed($event)"
-  (delete)="deleteBreed($event)"
+  (racaSearchTermChange)="racaSearchTerm = $event; updateFilteredRacas()"
+  (cancel)="closeRacaModal()"
+  (save)="saveRaca()"
+  (edit)="editRaca($event)"
+  (delete)="deleteRaca($event)"
 ></app-raca-manage-dialog>
 
 <app-cao-details-dialog

--- a/src/app/pages/admin/caes/caes.ts
+++ b/src/app/pages/admin/caes/caes.ts
@@ -162,22 +162,6 @@ export class CaesComponent implements OnInit {
     }
   }
 
-  onRacaFilterChange() {
-    this.updateFilteredRacas();
-  }
-
-  openBreedModal() {
-    this.openRacaModal();
-  }
-
-  canManageBreeds(): boolean {
-    return this.isAdmin;
-  }
-
-  get isLoading(): boolean {
-    return this.loading;
-  }
-
   get filteredCaes() {
     return this.caes.filter((cao) => {
       const matchesSearch =
@@ -213,10 +197,6 @@ export class CaesComponent implements OnInit {
       const years = Math.floor(ageInMonths / 12);
       return `${years} ${years === 1 ? "ano" : "anos"}`;
     }
-  }
-
-  formatAge(birthDate: Date): string {
-    return this.calculateAge(birthDate);
   }
 
   getRacaName(racaId?: string): string {
@@ -346,65 +326,11 @@ export class CaesComponent implements OnInit {
     return user ? user.role === "ADMIN" || user.role === "EDITOR" : false;
   }
 
-  get isSavingBreed() {
-    return this.racaModalLoading;
-  }
-
-  get editingBreedId() {
-    return this.isEditingRaca ? this.racaForm.racaId : null;
-  }
-
-  get currentBreed() {
-    return this.racaForm;
-  }
-
-  get breedForm() {
-    return {
-      valid: this.racaForm.nome.trim().length > 0,
-    };
-  }
-
-  cancelBreedEdit() {
-    this.closeRacaModal();
-  }
-
-  closeBreedModal() {
-    this.closeRacaModal();
-  }
-
-  saveBreed() {
-    this.saveRaca();
-  }
-
-  get selectedBreedId() {
-    return this.selectedRaca;
-  }
-
-  get showBreedModal() {
-    return this.showRacaModal;
-  }
-
   clearFilters() {
     this.searchTerm = "";
     this.selectedRaca = "";
     this.selectedStatus = "";
     this.loadCaes();
-  }
-
-  editBreed(raca: Raca) {
-    this.editRaca(raca);
-  }
-
-  deleteBreed(raca: Raca) {
-    this.deleteRaca(raca);
-  }
-
-  viewCao(cao: CaoListItem) {
-    console.log("Visualizar cão:", cao);
-  }
-
-  editCao(cao: CaoListItem) {
-    this.openCaoModal(cao);
   }
 
   openCaoModal(caoListItem: CaoListItem) {


### PR DESCRIPTION
Removed nearly 20 redundant alias methods and getters in `src/app/pages/admin/caes/caes.ts` and updated their usages in `src/app/pages/admin/caes/caes.html` to use the original methods or properties directly. This simplifies the component API and improves maintainability.

Specific changes:
- Replaced \`canManageBreeds()\` with \`isAdmin\`
- Replaced \`openBreedModal()\` with \`openRacaModal()\`
- Replaced \`formatAge()\` with \`calculateAge()\`
- Replaced \`isLoading\` with \`loading\`
- Replaced \`editCao()\` with \`openCaoModal()\`
- Removed unused \`viewCao()\` and \`breedForm\`
- Inlined simple logic from getters like \`editingBreedId\` directly into the template.