### PR TITLE
fix: secure token storage and mitigate XSS risk

### DIFF
--- a/src/app/pages/admin/components/top-menu/top-menu.ts
+++ b/src/app/pages/admin/components/top-menu/top-menu.ts
@@ -36,15 +36,10 @@ export class TopMenuComponent implements OnInit, OnDestroy {
   }
 
   private loadUserData() {
-    try {
-      const userData = localStorage.getItem('auth_user');
-      if (userData) {
-        const user = JSON.parse(userData);
-        this.username = user.userName || user.name || '';
-        this.userRole = this.translateRole(user.role) || '';
-      }
-    } catch (error) {
-      console.error('Erro ao carregar dados do usuário:', error);
+    const user = this.authService.getCurrentUser();
+    if (user) {
+      this.username = user.userName || user.name || '';
+      this.userRole = this.translateRole(user.role) || '';
     }
   }
 

--- a/src/app/pages/public/artigos/detalhe/artigo-leitura.ts
+++ b/src/app/pages/public/artigos/detalhe/artigo-leitura.ts
@@ -8,7 +8,6 @@ import {
 } from "@angular/core";
 import { CommonModule } from "@angular/common";
 import { ActivatedRoute, RouterModule } from "@angular/router";
-import { DomSanitizer, SafeHtml } from "@angular/platform-browser";
 import { ArtigosService } from "../../../../services/artigos.service";
 import type { Artigo } from "../../../../interfaces/artigo.interface";
 import { Subject, takeUntil } from "rxjs";
@@ -24,11 +23,10 @@ import { Subject, takeUntil } from "rxjs";
 export class ArtigoLeituraComponent implements OnInit, OnDestroy {
   private route = inject(ActivatedRoute);
   private artigosService = inject(ArtigosService);
-  private sanitizer = inject(DomSanitizer);
   private cdr = inject(ChangeDetectorRef);
 
   artigo?: Artigo;
-  conteudoSeguro?: SafeHtml;
+  conteudoSeguro?: string;
   loading = true;
   error: string | null = null;
 
@@ -71,9 +69,7 @@ export class ArtigoLeituraComponent implements OnInit, OnDestroy {
       .subscribe({
         next: (art) => {
           this.artigo = art;
-          this.conteudoSeguro = this.sanitizer.bypassSecurityTrustHtml(
-            this.extractHtmlFromContent(art.conteudo),
-          );
+          this.conteudoSeguro = this.extractHtmlFromContent(art.conteudo);
           this.totalCurtidas = art.curtidas || 0;
           this.totalVisualizacoes = art.visualizacoes || 0;
           this.loading = false;

--- a/src/app/pages/public/components/navbar/navbar.ts
+++ b/src/app/pages/public/components/navbar/navbar.ts
@@ -92,15 +92,10 @@ export class NavbarComponent implements OnInit, OnDestroy {
   }
 
   private loadUserData() {
-    try {
-      const userData = localStorage.getItem('auth_user');
-      if (userData) {
-        const user = JSON.parse(userData);
-        this.username = user.userName || user.name || '';
-        this.userRole = user.role || ''; // Directly use the role from the user object
-      }
-    } catch (error) {
-      console.error('Erro ao carregar dados do usuário:', error);
+    const user = this.authService.getCurrentUser();
+    if (user) {
+      this.username = user.userName || user.name || '';
+      this.userRole = user.role || ''; // Directly use the role from the user object
     }
   }
 

--- a/src/app/services/auth.service.spec.ts
+++ b/src/app/services/auth.service.spec.ts
@@ -47,8 +47,8 @@ describe('AuthService - Refresh Token Flow', () => {
       };
       const mockRefreshToken = 'valid-refresh-token';
 
-      localStorage.setItem('refreshToken', mockRefreshToken);
-      localStorage.setItem('userData', JSON.stringify(mockUser));
+      sessionStorage.setItem('refresh_token', mockRefreshToken);
+      sessionStorage.setItem('auth_user', JSON.stringify(mockUser));
 
       const mockRefreshResponse = {
         statusCode: 200,
@@ -70,14 +70,14 @@ describe('AuthService - Refresh Token Flow', () => {
 
       const req = httpMock.expectOne(`${environment.apiUrl}/auth/refresh`);
       expect(req.request.method).toBe('POST');
-      expect(req.request.body).toEqual({ refreshToken: mockRefreshToken });
+      expect(req.request.body).toEqual({ refresh_token: mockRefreshToken });
 
       req.flush(mockRefreshResponse);
     });
 
     it('deve limpar sessão quando refresh token é inválido', () => {
       const mockRefreshToken = 'invalid-refresh-token';
-      localStorage.setItem('refreshToken', mockRefreshToken);
+      sessionStorage.setItem('refresh_token', mockRefreshToken);
 
       service.refreshToken().subscribe({
         next: () => fail('Deveria ter falhado'),
@@ -106,7 +106,7 @@ describe('AuthService - Refresh Token Flow', () => {
         createdAt: '2024-01-01T00:00:00Z'
       };
       service.setTokens('valid-access-token', 'valid-refresh-token');
-      localStorage.setItem('userData', JSON.stringify(mockUser));
+      sessionStorage.setItem('auth_user', JSON.stringify(mockUser));
 
       service.ensureAuthenticated().subscribe(result => {
         expect(result).toBe(true);
@@ -127,8 +127,8 @@ describe('AuthService - Refresh Token Flow', () => {
       };
       const mockRefreshToken = 'valid-refresh-token';
 
-      localStorage.setItem('refreshToken', mockRefreshToken);
-      localStorage.setItem('userData', JSON.stringify(mockUser));
+      sessionStorage.setItem('refresh_token', mockRefreshToken);
+      sessionStorage.setItem('auth_user', JSON.stringify(mockUser));
 
       const mockRefreshResponse = {
         statusCode: 200,
@@ -174,15 +174,17 @@ describe('AuthService - Refresh Token Flow', () => {
 
       // Caso 2: Com access token - não precisa fazer refresh
       service.setTokens('access-token', 'refresh-token');
-      localStorage.setItem('userData', JSON.stringify(mockUser));
+      sessionStorage.setItem('auth_user', JSON.stringify(mockUser));
       expect(service.canRefreshToken()).toBe(false);
 
       // Caso 3: Sem access token mas com refresh token e dados do usuário - pode fazer refresh
-      sessionStorage.removeItem('accessToken');
+      // We need to clear the in-memory access token as well
+      (service as any).accessToken = null;
+      sessionStorage.removeItem('access_token');
       expect(service.canRefreshToken()).toBe(true);
 
       // Caso 4: Sem dados do usuário - não pode fazer refresh
-      localStorage.removeItem('userData');
+      sessionStorage.removeItem('auth_user');
       expect(service.canRefreshToken()).toBe(false);
     });
   });

--- a/src/app/services/auth.service.ts
+++ b/src/app/services/auth.service.ts
@@ -16,11 +16,12 @@ import { Usuario } from '../interfaces/usuario.interface';
 export class AuthService {
   private apiUrl = `${environment.apiUrl}/auth`;
   private userKey = 'auth_user';
-  private refreshTokenKey = 'refresh_token'; // Key used to store in localStorage (matches backend response)
+  private refreshTokenKey = 'refresh_token'; // Key for sessionStorage
   private accessTokenKey = 'access_token'; // Key for sessionStorage
 
-  // access_token is stored in memory for better security (XSS)
+  // Tokens are stored in memory for better security (XSS)
   private accessToken: string | null = null;
+  private refreshTokenValue: string | null = null;
 
   // Flag para evitar múltiplas chamadas de logout simultâneas
   private isLoggingOut = false;
@@ -43,17 +44,20 @@ export class AuthService {
 
   private initializeAuthenticationState(): void {
     const accessToken = sessionStorage.getItem(this.accessTokenKey);
+    const refreshToken = sessionStorage.getItem(this.refreshTokenKey);
 
-    // If an access token is present in sessionStorage, restore it to memory and set authenticated state to true
+    // If tokens are present in sessionStorage, restore them to memory
     if (accessToken) {
       this.accessToken = accessToken;
       this.isAuthenticatedSubject.next(true);
       console.log('AuthService: Access token restaurado do sessionStorage. Estado de autenticação: true');
     } else {
-      // If no access token, assume not authenticated initially.
-      // initializeAuth will handle refresh token logic.
       this.isAuthenticatedSubject.next(false);
       console.log('AuthService: Nenhum access token encontrado no sessionStorage. Estado de autenticação: false');
+    }
+
+    if (refreshToken) {
+      this.refreshTokenValue = refreshToken;
     }
   }
 
@@ -122,7 +126,7 @@ export class AuthService {
   }
 
   refreshToken(): Observable<RefreshResponse> {
-    const storedRefreshToken = this.getRefreshToken(); // Get the refresh token from localStorage
+    const storedRefreshToken = this.getRefreshToken(); // Get the refresh token from storage
     if (!storedRefreshToken) {
       this.clearSession();
       return throwError(() => new Error('No refresh token available.'));
@@ -173,7 +177,14 @@ export class AuthService {
   }
 
   getRefreshToken(): string | null {
-    return localStorage.getItem(this.refreshTokenKey);
+    if (this.refreshTokenValue) {
+      return this.refreshTokenValue;
+    }
+    const storedToken = sessionStorage.getItem(this.refreshTokenKey);
+    if (storedToken) {
+      this.refreshTokenValue = storedToken;
+    }
+    return this.refreshTokenValue;
   }
 
   private handleAuthentication(accessToken: string, refreshToken: string, user: Usuario): void {
@@ -184,20 +195,21 @@ export class AuthService {
   }
 
   public setTokens(accessToken: string, refreshToken: string): void {
-    console.log('AuthService: Salvando tokens. AccessToken (memória): ', accessToken ? 'presente' : 'ausente', '; RefreshToken (localStorage): ', refreshToken ? 'presente' : 'ausente');
+    console.log('AuthService: Salvando tokens. AccessToken: ', accessToken ? 'presente' : 'ausente', '; RefreshToken: ', refreshToken ? 'presente' : 'ausente');
     this.accessToken = accessToken;
-    // Armazena o access token no sessionStorage para persistir durante a sessão
+    this.refreshTokenValue = refreshToken;
+
+    // Tokens are stored in sessionStorage for better security (not persistent across sessions)
     sessionStorage.setItem(this.accessTokenKey, accessToken);
-    localStorage.setItem(this.refreshTokenKey, refreshToken);
+    sessionStorage.setItem(this.refreshTokenKey, refreshToken);
+
     this.isAuthenticatedSubject.next(true);
-    console.log('AuthService: Tokens salvos. RefreshToken no localStorage agora é:', localStorage.getItem(this.refreshTokenKey));
   }
 
   private setUserData(userData: Usuario): void {
-    console.log('AuthService: Salvando dados do usuário no localStorage:', userData);
-    localStorage.setItem(this.userKey, JSON.stringify(userData));
+    console.log('AuthService: Salvando dados do usuário no sessionStorage:', userData);
+    sessionStorage.setItem(this.userKey, JSON.stringify(userData));
     this.currentUserSubject.next(userData);
-    console.log('AuthService: Dados do usuário salvos. Usuário no localStorage agora é:', localStorage.getItem(this.userKey));
   }
 
   public updateUserData(updatedData: Partial<Usuario>): void {
@@ -222,21 +234,28 @@ export class AuthService {
    */
   public clearSession(): void {
     this.accessToken = null;
+    this.refreshTokenValue = null;
     this.isLoggingOut = false; // Reset da flag de logout
+
     sessionStorage.removeItem(this.accessTokenKey);
+    sessionStorage.removeItem(this.refreshTokenKey);
+    sessionStorage.removeItem(this.userKey);
+
+    // Also clear from localStorage just in case there are legacy tokens
     localStorage.removeItem(this.refreshTokenKey);
     localStorage.removeItem(this.userKey);
+
     this.currentUserSubject.next(null);
     this.isAuthenticatedSubject.next(false);
   }
 
   private getUserFromStorage(): Usuario | null {
-    const userStr = localStorage.getItem(this.userKey);
+    const userStr = sessionStorage.getItem(this.userKey) || localStorage.getItem(this.userKey);
     if (userStr) {
       try {
         return JSON.parse(userStr) as Usuario;
       } catch (error) {
-        console.error('AuthService: Erro ao parsear dados do usuário do localStorage:', error);
+        console.error('AuthService: Erro ao parsear dados do usuário do storage:', error);
         this.clearSession();
         return null;
       }


### PR DESCRIPTION
- Move refresh tokens and user data from localStorage to sessionStorage to limit credential lifespan.
- Remove bypassSecurityTrustHtml in ArtigoLeituraComponent to prevent XSS.
- Refactor components to use AuthService instead of direct localStorage access.
- Update unit tests to match new storage strategy and correct API field names.