### PR TITLE
fix: resolve memory leaks in NavbarComponent subscriptions

### DIFF
--- a/src/app/pages/public/components/navbar/navbar.ts
+++ b/src/app/pages/public/components/navbar/navbar.ts
@@ -1,7 +1,8 @@
 import { Component, HostListener, ElementRef, OnInit, OnDestroy } from '@angular/core';
 import { Router, RouterModule } from '@angular/router';
 import { CommonModule } from '@angular/common';
-import { Observable } from 'rxjs';
+import { Observable, Subject } from 'rxjs';
+import { takeUntil } from 'rxjs/operators';
 import { AuthService } from '../../../../services/auth.service';
 import type { Usuario } from '../../../../interfaces/usuario.interface';
 
@@ -43,6 +44,7 @@ export class NavbarComponent implements OnInit, OnDestroy {
   // Observables para o estado de autenticação e dados do usuário
   public isAuthenticated$: Observable<boolean>;
   public currentUser$: Observable<Usuario | null>;
+  private destroy$ = new Subject<void>();
 
   constructor(
     private router: Router,
@@ -55,24 +57,29 @@ export class NavbarComponent implements OnInit, OnDestroy {
 
   ngOnInit() {
     this.loadUserData();
-    this.currentUser$.subscribe(user => {
-      if (user) {
-        this.username = user.userName || user.name || '';
-        this.userRole = user.role || ''; // Directly use the role from the user object
-      } else {
-        this.username = '';
-        this.userRole = '';
-      }
-    });
+    this.currentUser$
+      .pipe(takeUntil(this.destroy$))
+      .subscribe(user => {
+        if (user) {
+          this.username = user.userName || user.name || '';
+          this.userRole = user.role || ''; // Directly use the role from the user object
+        } else {
+          this.username = '';
+          this.userRole = '';
+        }
+      });
 
     // Atualiza estado inicialmente conforme posição da página
     this.updateScrollState();
     this.updateCompactState();
-    this.router.events.subscribe(() => this.updateCompactState());
+    this.router.events
+      .pipe(takeUntil(this.destroy$))
+      .subscribe(() => this.updateCompactState());
   }
 
   ngOnDestroy() {
-    // No specific cleanup needed for now, similar to top-menu.ts
+    this.destroy$.next();
+    this.destroy$.complete();
   }
 
   // Controla estado visual (shrink) ao rolar a página


### PR DESCRIPTION
- Introduced `destroy$` Subject to manage component lifecycle.
- Applied `takeUntil(this.destroy$)` to `router.events` and `currentUser$` subscriptions.
- Implemented `ngOnDestroy` to emit and complete the `destroy$` Subject.