### PR TITLE
Refactor deprecated subscribe usage in NavbarComponent

### DIFF
--- a/src/app/pages/public/components/navbar/navbar.ts
+++ b/src/app/pages/public/components/navbar/navbar.ts
@@ -59,13 +59,15 @@ export class NavbarComponent implements OnInit, OnDestroy {
     this.loadUserData();
     this.currentUser$
       .pipe(takeUntil(this.destroy$))
-      .subscribe(user => {
-        if (user) {
-          this.username = user.userName || user.name || '';
-          this.userRole = user.role || ''; // Directly use the role from the user object
-        } else {
-          this.username = '';
-          this.userRole = '';
+      .subscribe({
+        next: (user) => {
+          if (user) {
+            this.username = user.userName || user.name || '';
+            this.userRole = user.role || ''; // Directly use the role from the user object
+          } else {
+            this.username = '';
+            this.userRole = '';
+          }
         }
       });
 
@@ -74,7 +76,9 @@ export class NavbarComponent implements OnInit, OnDestroy {
     this.updateCompactState();
     this.router.events
       .pipe(takeUntil(this.destroy$))
-      .subscribe(() => this.updateCompactState());
+      .subscribe({
+        next: () => this.updateCompactState()
+      });
   }
 
   ngOnDestroy() {


### PR DESCRIPTION
Updated deprecated RxJS `subscribe` usage in `NavbarComponent` to use the observer object syntax. This improves code health and maintainability.

---
*PR created automatically by Jules for task [8850251707347530852](https://jules.google.com/task/8850251707347530852) started by @lucascampos42*